### PR TITLE
Add TabCompleteResponsePacket and TabCompleteRequestPacket.

### DIFF
--- a/Sources/SwiftCraft/Packets/PacketLibrary.swift
+++ b/Sources/SwiftCraft/Packets/PacketLibrary.swift
@@ -54,6 +54,7 @@ public struct DefaultPacketLibrary: PacketLibrary {
         BlockActionPacket.self,                             // 0x0A
         BlockChangePacket.self,                             // 0x0B
         ServerDifficultyPacket.self,                        // 0x0D
+        TabCompleteResponsePacket.self,                     // 0x0E
         ReceiveChatMessagePacket.self,                      // 0x0F
         MultiBlockChangePacket.self,                        // 0x10
         WindowItemsPacket.self,                             // 0x14

--- a/Sources/SwiftCraft/Packets/Play/Clientbound/TabCompleteResponsePacket.swift
+++ b/Sources/SwiftCraft/Packets/Play/Clientbound/TabCompleteResponsePacket.swift
@@ -1,0 +1,23 @@
+//
+//  TabCompleteResponse.swift
+//  SwiftCraft
+//
+//  Created by Noah Peeters on 28.06.18.
+//  Copyright © 2018 Noah Peeters. All rights reserved.
+//
+
+import Foundation
+
+/// Send by the server as a response to the TabCompleteRequest.
+public struct TabCompleteResponsePacket: DeserializablePacket, PlayPacketIDProvider {
+    public static func packetIndex(context: SerializationContext) -> Int? {
+        return 0x0E
+    }
+
+    /// The list of completions for the last word.
+    public let completions: [String]
+
+    public init<Buffer: ByteReadBuffer>(from buffer: Buffer, context: SerializationContext) throws {
+        completions = try [String](from: buffer)
+    }
+}

--- a/Sources/SwiftCraft/Packets/Play/Serverbound/TabCompleteRequestPacket.swift
+++ b/Sources/SwiftCraft/Packets/Play/Serverbound/TabCompleteRequestPacket.swift
@@ -1,0 +1,39 @@
+//
+//  TabCompleteRequestPacket.swift
+//  SwiftCraft
+//
+//  Created by Noah Peeters on 28.06.18.
+//  Copyright © 2018 Noah Peeters. All rights reserved.
+//
+
+import Foundation
+
+/// Sent when the user presses tab while writing text.
+///
+/// The server will responde with a list of completions.
+public struct TabCompleteRequestPacket: BufferSerializablePacket, PlayPacketIDProvider {
+    public static func packetIndex(context: SerializationContext) -> Int? {
+        return 0x01
+    }
+
+    /// The text to complete.
+    public let text: String
+
+    /// If true, the server will interprete the text as a command. This is used in command blocks.
+    public let assumeCommand: Bool
+
+    /// The position the player is looking at.
+    public let position: BlockPosition?
+
+    public func serializeData<Buffer: ByteWriteBuffer>(to buffer: Buffer, context: SerializationContext) {
+        text.serialize(to: buffer)
+        assumeCommand.serialize(to: buffer)
+        position.serialize(to: buffer)
+    }
+}
+
+extension MinecraftClient {
+    public func sendTabCompleteRequest(text: String, assumeCommand: Bool, position: BlockPosition?) {
+        sendPacket(TabCompleteRequestPacket(text: text, assumeCommand: assumeCommand, position: position))
+    }
+}

--- a/SwiftCraft.xcodeproj/project.pbxproj
+++ b/SwiftCraft.xcodeproj/project.pbxproj
@@ -122,6 +122,12 @@
 		40778F8720DAC8E500B8BB99 /* AdvancementsPacket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40778F8620DAC8E500B8BB99 /* AdvancementsPacket.swift */; };
 		40778F8920DAC94900B8BB99 /* Identifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40778F8820DAC94900B8BB99 /* Identifier.swift */; };
 		40778F8B20DACAEE00B8BB99 /* Dictionary+Serializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40778F8A20DACAEE00B8BB99 /* Dictionary+Serializable.swift */; };
+		407C862C2107A5C5001ABA56 /* TabCompleteResponsePacketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 407C86282107A4F6001ABA56 /* TabCompleteResponsePacketTests.swift */; };
+		407C862D2107A5C6001ABA56 /* TabCompleteResponsePacketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 407C86282107A4F6001ABA56 /* TabCompleteResponsePacketTests.swift */; };
+		407C862E2107A5C7001ABA56 /* TabCompleteResponsePacketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 407C86282107A4F6001ABA56 /* TabCompleteResponsePacketTests.swift */; };
+		407C86312107A6DF001ABA56 /* TabCompleteRequestPacketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 407C862F2107A68D001ABA56 /* TabCompleteRequestPacketTests.swift */; };
+		407C86322107A6DF001ABA56 /* TabCompleteRequestPacketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 407C862F2107A68D001ABA56 /* TabCompleteRequestPacketTests.swift */; };
+		407C86332107A6E0001ABA56 /* TabCompleteRequestPacketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 407C862F2107A68D001ABA56 /* TabCompleteRequestPacketTests.swift */; };
 		407F2C0720DDC10F0078B8F1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 407F2C0620DDC10F0078B8F1 /* AppDelegate.swift */; };
 		407F2C0C20DDC10F0078B8F1 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 407F2C0A20DDC10F0078B8F1 /* Main.storyboard */; };
 		407F2C0E20DDC10F0078B8F1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 407F2C0D20DDC10F0078B8F1 /* Assets.xcassets */; };
@@ -727,6 +733,8 @@
 		40778F8620DAC8E500B8BB99 /* AdvancementsPacket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancementsPacket.swift; sourceTree = "<group>"; };
 		40778F8820DAC94900B8BB99 /* Identifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identifier.swift; sourceTree = "<group>"; };
 		40778F8A20DACAEE00B8BB99 /* Dictionary+Serializable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Serializable.swift"; sourceTree = "<group>"; };
+		407C86282107A4F6001ABA56 /* TabCompleteResponsePacketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabCompleteResponsePacketTests.swift; sourceTree = "<group>"; };
+		407C862F2107A68D001ABA56 /* TabCompleteRequestPacketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabCompleteRequestPacketTests.swift; sourceTree = "<group>"; };
 		407F2C0420DDC10F0078B8F1 /* SwiftCraftiOSApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftCraftiOSApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		407F2C0620DDC10F0078B8F1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		407F2C0B20DDC10F0078B8F1 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -1788,6 +1796,8 @@
 			children = (
 				40F058AF20E5726500CE003E /* MockSerializationContext.swift */,
 				40F058AB20E56DAF00CE003E /* DisconnectPlayPacketTests.swift */,
+				407C86282107A4F6001ABA56 /* TabCompleteResponsePacketTests.swift */,
+				407C862F2107A68D001ABA56 /* TabCompleteRequestPacketTests.swift */,
 			);
 			path = "Packets Tests";
 			sourceTree = "<group>";
@@ -2458,10 +2468,12 @@
 				401C5ADF20E0025500E9B461 /* CompressionTests.swift in Sources */,
 				13879E2920E13BA100EEED99 /* NumberSerializationTests.swift in Sources */,
 				40E2141820E196F300730052 /* TranslationTests.swift in Sources */,
+				407C86322107A6DF001ABA56 /* TabCompleteRequestPacketTests.swift in Sources */,
 				4024AB8820B22418008790F2 /* BufferTests.swift in Sources */,
 				40F058B120E5726500CE003E /* MockSerializationContext.swift in Sources */,
 				4024AB9220B231A2008790F2 /* DataTypesSerializationTests.swift in Sources */,
 				40E2141320E1915A00730052 /* BlockPositionTests.swift in Sources */,
+				407C862D2107A5C6001ABA56 /* TabCompleteResponsePacketTests.swift in Sources */,
 				4068070120B3200600B116C4 /* TCPClientTests.swift in Sources */,
 				40F058AD20E56DAF00CE003E /* DisconnectPlayPacketTests.swift in Sources */,
 			);
@@ -2476,10 +2488,12 @@
 				401C5ADE20E0025500E9B461 /* CompressionTests.swift in Sources */,
 				13879E2820E13BA100EEED99 /* NumberSerializationTests.swift in Sources */,
 				40E2141620E196F100730052 /* TranslationTests.swift in Sources */,
+				407C86312107A6DF001ABA56 /* TabCompleteRequestPacketTests.swift in Sources */,
 				40767E5320DF09060082A6D1 /* DataTypesSerializationTests.swift in Sources */,
 				40F058B020E5726500CE003E /* MockSerializationContext.swift in Sources */,
 				40767E5420DF09060082A6D1 /* TCPClientTests.swift in Sources */,
 				40E2141020E1905700730052 /* BlockPositionTests.swift in Sources */,
+				407C862C2107A5C5001ABA56 /* TabCompleteResponsePacketTests.swift in Sources */,
 				40767E5220DF09060082A6D1 /* BufferTests.swift in Sources */,
 				40F058AC20E56DAF00CE003E /* DisconnectPlayPacketTests.swift in Sources */,
 			);
@@ -2494,10 +2508,12 @@
 				401C5AE020E0025500E9B461 /* CompressionTests.swift in Sources */,
 				13879E2A20E13BA100EEED99 /* NumberSerializationTests.swift in Sources */,
 				40E2141720E196F200730052 /* TranslationTests.swift in Sources */,
+				407C86332107A6E0001ABA56 /* TabCompleteRequestPacketTests.swift in Sources */,
 				40767E4F20DF09050082A6D1 /* DataTypesSerializationTests.swift in Sources */,
 				40F058B220E5726500CE003E /* MockSerializationContext.swift in Sources */,
 				40767E5020DF09050082A6D1 /* TCPClientTests.swift in Sources */,
 				40E2141120E1905700730052 /* BlockPositionTests.swift in Sources */,
+				407C862E2107A5C7001ABA56 /* TabCompleteResponsePacketTests.swift in Sources */,
 				40767E4E20DF09050082A6D1 /* BufferTests.swift in Sources */,
 				40F058AE20E56DAF00CE003E /* DisconnectPlayPacketTests.swift in Sources */,
 			);

--- a/SwiftCraft.xcodeproj/project.pbxproj
+++ b/SwiftCraft.xcodeproj/project.pbxproj
@@ -447,6 +447,12 @@
 		40AEEE7B20DBD0D300E774CA /* EntityLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AEEE7A20DBD0D300E774CA /* EntityLocation.swift */; };
 		40AEEE7D20DBD0E800E774CA /* SlotContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AEEE7C20DBD0E800E774CA /* SlotContent.swift */; };
 		40AEEE7F20DBD0FF00E774CA /* General.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AEEE7E20DBD0FF00E774CA /* General.swift */; };
+		40C7023320E579C300000919 /* TabCompleteRequestPacket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C7023220E579C300000919 /* TabCompleteRequestPacket.swift */; };
+		40C7023420E579C300000919 /* TabCompleteRequestPacket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C7023220E579C300000919 /* TabCompleteRequestPacket.swift */; };
+		40C7023520E579C300000919 /* TabCompleteRequestPacket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C7023220E579C300000919 /* TabCompleteRequestPacket.swift */; };
+		40C7023720E579DA00000919 /* TabCompleteResponsePacket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C7023620E579DA00000919 /* TabCompleteResponsePacket.swift */; };
+		40C7023820E579DA00000919 /* TabCompleteResponsePacket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C7023620E579DA00000919 /* TabCompleteResponsePacket.swift */; };
+		40C7023920E579DA00000919 /* TabCompleteResponsePacket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C7023620E579DA00000919 /* TabCompleteResponsePacket.swift */; };
 		40C74D1720DD8B9F008CC291 /* CrypoWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C74D1620DD8B9F008CC291 /* CrypoWrapper.swift */; };
 		40C74D1920DD8D2D008CC291 /* SwCrypt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C74D1820DD8D2D008CC291 /* SwCrypt.swift */; };
 		40C74D2320DDB21D008CC291 /* SwiftCraft.h in Headers */ = {isa = PBXBuildFile; fileRef = 40C74D2120DDB21D008CC291 /* SwiftCraft.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -798,6 +804,8 @@
 		40AEEE7E20DBD0FF00E774CA /* General.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = General.swift; sourceTree = "<group>"; };
 		40AEEE8220DBE5F900E774CA /* Package.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		40BCC65A20DE7C2E0023BC2E /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		40C7023220E579C300000919 /* TabCompleteRequestPacket.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabCompleteRequestPacket.swift; sourceTree = "<group>"; };
+		40C7023620E579DA00000919 /* TabCompleteResponsePacket.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabCompleteResponsePacket.swift; sourceTree = "<group>"; };
 		40C74D1620DD8B9F008CC291 /* CrypoWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrypoWrapper.swift; sourceTree = "<group>"; };
 		40C74D1820DD8D2D008CC291 /* SwCrypt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwCrypt.swift; sourceTree = "<group>"; };
 		40C74D1F20DDB21D008CC291 /* SwiftCraft.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftCraft.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1124,6 +1132,7 @@
 				408C67E820DAB5F90090A1F0 /* BlockActionPacket.swift */,
 				4024C60120D953AB00493A86 /* BlockChangePacket.swift */,
 				40DAC2D820B985420017FEBD /* ServerDifficultyPacket.swift */,
+				40C7023620E579DA00000919 /* TabCompleteResponsePacket.swift */,
 				4022B07620B4D20C00B4E680 /* ReceiveChatMessagePacket.swift */,
 				40E314FD20B6110900C9E271 /* MultiBlockChangePacket.swift */,
 				4024C5C820D9077A00493A86 /* WindowItemsPacket.swift */,
@@ -1170,6 +1179,7 @@
 			isa = PBXGroup;
 			children = (
 				40695BA120DAF6A1007C1C36 /* TeleportConfirmPacket.swift */,
+				40C7023220E579C300000919 /* TabCompleteRequestPacket.swift */,
 				40E314F220B5F65300C9E271 /* SendChatMessagePacket.swift */,
 				408E63EA20B9A8B600AE9C2D /* ClientStatusPacket.swift */,
 				4022B07B20B4E13B00B4E680 /* KeepaliveResponsePacket.swift */,
@@ -2318,6 +2328,7 @@
 				408E641720BB096300AE9C2D /* UpdateHealthPacket.swift in Sources */,
 				40778F8920DAC94900B8BB99 /* Identifier.swift in Sources */,
 				4024AB8220B21E67008790F2 /* WriteBuffer.swift in Sources */,
+				40C7023820E579DA00000919 /* TabCompleteResponsePacket.swift in Sources */,
 				408E63E520B992D900AE9C2D /* EntityStatusPacket.swift in Sources */,
 				408E63EF20B9D4FC00AE9C2D /* PlayerListPacket.swift in Sources */,
 				40778F8B20DACAEE00B8BB99 /* Dictionary+Serializable.swift in Sources */,
@@ -2389,6 +2400,7 @@
 				408E640F20BAFCEE00AE9C2D /* UnloadChunkPacket.swift in Sources */,
 				40695B9120DAEE27007C1C36 /* PlayerReactor.swift in Sources */,
 				40DAC2DD20B989BC0017FEBD /* ReceivedPlayerAbilitiesPacket.swift in Sources */,
+				40C7023420E579C300000919 /* TabCompleteRequestPacket.swift in Sources */,
 				408E640B20BAF60E00AE9C2D /* World.swift in Sources */,
 				408C67EF20DABC270090A1F0 /* WorldBorderPacket.swift in Sources */,
 				408C67E320DAB1D70090A1F0 /* ReceivedAnimationPacket.swift in Sources */,
@@ -2520,6 +2532,7 @@
 				4084643120DDB99300C2ACC4 /* BlockActionPacket.swift in Sources */,
 				4084645220DDB99300C2ACC4 /* SpawnPaintingPacket.swift in Sources */,
 				4084644520DDB99300C2ACC4 /* NBT.swift in Sources */,
+				40C7023920E579DA00000919 /* TabCompleteResponsePacket.swift in Sources */,
 				4084644B20DDB99300C2ACC4 /* UnloadChunkPacket.swift in Sources */,
 				4084648520DDB99300C2ACC4 /* MultiBlockChangePacket.swift in Sources */,
 				4084644320DDB99300C2ACC4 /* SwCrypt.swift in Sources */,
@@ -2591,6 +2604,7 @@
 				4084645420DDB99300C2ACC4 /* CrypoWrapper.swift in Sources */,
 				4084643220DDB99300C2ACC4 /* CollectItemPacket.swift in Sources */,
 				4084643820DDB99300C2ACC4 /* PacketIDProvider.swift in Sources */,
+				40C7023520E579C300000919 /* TabCompleteRequestPacket.swift in Sources */,
 				4084643720DDB99300C2ACC4 /* PlayerListPacket.swift in Sources */,
 				4084644D20DDB99300C2ACC4 /* AttachEntityPacket.swift in Sources */,
 				4084644C20DDB99300C2ACC4 /* PacketID.swift in Sources */,
@@ -2676,6 +2690,7 @@
 				4084636520DDB3DD00C2ACC4 /* SerializablePacket.swift in Sources */,
 				408463B020DDB3DD00C2ACC4 /* KeepaliveRequestPacket.swift in Sources */,
 				4084638820DDB3DD00C2ACC4 /* BlockActionPacket.swift in Sources */,
+				40C7023720E579DA00000919 /* TabCompleteResponsePacket.swift in Sources */,
 				4084639E20DDB3DD00C2ACC4 /* CollectItemPacket.swift in Sources */,
 				4084638720DDB3DD00C2ACC4 /* ChatMessageLocation.swift in Sources */,
 				4084634A20DDB3DD00C2ACC4 /* SpawnPositionPacket.swift in Sources */,
@@ -2747,6 +2762,7 @@
 				4084636E20DDB3DD00C2ACC4 /* EffectPacket.swift in Sources */,
 				408463A520DDB3DD00C2ACC4 /* PacketLibrary.swift in Sources */,
 				4084636C20DDB3DD00C2ACC4 /* SoundEffectPacket.swift in Sources */,
+				40C7023320E579C300000919 /* TabCompleteRequestPacket.swift in Sources */,
 				4084636D20DDB3DD00C2ACC4 /* EntityVelocity.swift in Sources */,
 				4084637A20DDB3DD00C2ACC4 /* ChunkSection.swift in Sources */,
 				4084636A20DDB3DD00C2ACC4 /* StatusRequestPacket.swift in Sources */,

--- a/Tests/SwiftCraftTests/Packets Tests/TabCompleteRequestPacketTests.swift
+++ b/Tests/SwiftCraftTests/Packets Tests/TabCompleteRequestPacketTests.swift
@@ -1,0 +1,36 @@
+//
+//  TabCompleteRequestPacketTests.swift
+//  SwiftCraft iOS
+//
+//  Created by Noah Peeters on 24.07.18.
+//  Copyright © 2018 Noah Peeters. All rights reserved.
+//
+
+import Foundation
+import Quick
+import Nimble
+@testable import SwiftCraft
+
+public class TabCompleteRequestPacketTests: QuickSpec {
+    public override func spec() {
+        context("checking with protocol version 340") {
+            describe("serializing") {
+                var packetData: ByteArray?
+
+                beforeEach {
+                    let packet = TabCompleteRequestPacket(text: "/hello", assumeCommand: true, position: nil)
+                    packetData = packet.serializedData(context: MockSerializationContext.play340)
+                }
+
+                it("has the correct content") {
+                    expect(packetData).to(equal([6, 0x2F, 0x68, 0x65, 0x6C, 0x6C, 0x6F, 1, 0]))
+                }
+            }
+
+            it("has the correct packet id") {
+                expect(TabCompleteRequestPacket.packetID(context: MockSerializationContext.play340))
+                    .to(equal(PacketID(connectionState: .play, id: 0x01)))
+            }
+        }
+    }
+}

--- a/Tests/SwiftCraftTests/Packets Tests/TabCompleteResponsePacketTests.swift
+++ b/Tests/SwiftCraftTests/Packets Tests/TabCompleteResponsePacketTests.swift
@@ -1,0 +1,46 @@
+//
+//  TabCompleteResponsePacketTests.swift
+//  SwiftCraft iOS
+//
+//  Created by Noah Peeters on 24.07.18.
+//  Copyright © 2018 Noah Peeters. All rights reserved.
+//
+
+import Foundation
+import Quick
+import Nimble
+@testable import SwiftCraft
+
+public class TabCompleteResponsePacketTests: QuickSpec {
+    public override func spec() {
+        context("checking with protocol version 340") {
+            describe("deserializing") {
+                var packet: TabCompleteResponsePacket?
+
+                beforeEach {
+                    packet = try? TabCompleteResponsePacket(
+                        from: [
+                            2,
+                            5, 0x48, 0x65, 0x6C, 0x6C, 0x6F,
+                            5, 0x57, 0x6F, 0x72, 0x6C, 0x64
+                        ],
+                        context: MockSerializationContext.play340)
+                }
+
+                it("succeds") {
+                    expect(packet).toNot(beNil())
+                }
+
+                it("has the correct message") {
+                    let message = packet?.completions
+                    expect(message).to(equal(["Hello", "World"]))
+                }
+            }
+
+            it("has the correct packet id") {
+                expect(TabCompleteResponsePacket.packetID(context: MockSerializationContext.play340))
+                    .to(equal(PacketID(connectionState: .play, id: 0x0E)))
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds packets to request and receive tab completions used in the Minecraft chat for command/username completion.

Close #43 (request) and close #14 (response)